### PR TITLE
Fix pubmed timeout integer parsing error

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,6 +4,8 @@ Simple application configuration.
 
 from pydantic_settings import BaseSettings
 from typing import Optional
+from pydantic import field_validator
+import os
 
 
 class Settings(BaseSettings):
@@ -38,8 +40,18 @@ class Settings(BaseSettings):
     pubmed_max_results: int = 5
     pubmed_timeout: int = 15
     
+    @field_validator('pubmed_timeout', mode='before')
+    @classmethod
+    def parse_pubmed_timeout(cls, v):
+        """Parse pubmed_timeout, handling common formatting issues"""
+        if isinstance(v, str):
+            # Remove trailing dots and convert to int
+            v = v.rstrip('.')
+            return int(float(v))
+        return v
+    
     class Config:
-        env_file = ".env"
+        env_file = [".env", "../.env", "../../.env"]
         case_sensitive = False
         
     @property


### PR DESCRIPTION
Add robust parsing for `pubmed_timeout` and expand `.env` search paths to fix a Pydantic validation error.

The application failed to start due to a Pydantic `ValidationError` where `pubmed_timeout` was expected to be an integer but received a string like `'15.'`. This PR adds a `@field_validator` to correctly parse such strings into integers and expands the `env_file` search paths to ensure the configuration is loaded reliably from various `.env` locations.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ceef1c4-4278-4fa0-b7b5-03686c070740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ceef1c4-4278-4fa0-b7b5-03686c070740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

