### PR TITLE
Explore connecting chat-agent-app-ui to backend

### DIFF
--- a/chat-agent-app-ui/app/api/chat/route.ts
+++ b/chat-agent-app-ui/app/api/chat/route.ts
@@ -1,16 +1,98 @@
-import { openai } from "@ai-sdk/openai";
-import {
-  streamText,
-  UIMessage,
-  convertToModelMessages,
-} from "ai";
+import { UIMessage } from "ai";
+
+// Backend configuration
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
 
 export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json();
-  const result = streamText({
-    model: openai("gpt-4o"),
-    messages: convertToModelMessages(messages),
-  });
+  try {
+    const { messages }: { messages: UIMessage[] } = await req.json();
+    
+    // Transform messages to backend format
+    const backendMessages = messages.map(msg => ({
+      role: msg.role,
+      content: msg.content
+    }));
 
-  return result.toUIMessageStreamResponse();
+    // Prepare request for backend
+    const backendRequest = {
+      messages: backendMessages,
+      workflow: "pubmed_research", // Default workflow
+      session_id: null // Could be enhanced to include session management
+    };
+
+    // Call backend streaming endpoint
+    const response = await fetch(`${BACKEND_URL}/api/v1/chat/stream`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(backendRequest),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Backend error: ${response.status} ${response.statusText}`);
+    }
+
+    // Create a ReadableStream to transform backend response to AI SDK format
+    const transformStream = new ReadableStream({
+      async start(controller) {
+        const reader = response.body?.getReader();
+        if (!reader) {
+          controller.close();
+          return;
+        }
+
+        const decoder = new TextDecoder();
+        
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n').filter(line => line.trim());
+
+            for (const line of lines) {
+              try {
+                // Backend sends JSON chunks like: {"type": "text", "content": "word"}
+                const parsed = JSON.parse(line);
+                if (parsed.type === "text" && parsed.content) {
+                  // Transform to AI SDK format
+                  const aiSDKChunk = `0:"${parsed.content.replace(/"/g, '\\"')}"\n`;
+                  controller.enqueue(new TextEncoder().encode(aiSDKChunk));
+                }
+              } catch (parseError) {
+                // If not JSON, treat as plain text
+                const aiSDKChunk = `0:"${line.replace(/"/g, '\\"')}"\n`;
+                controller.enqueue(new TextEncoder().encode(aiSDKChunk));
+              }
+            }
+          }
+        } catch (error) {
+          console.error("Stream processing error:", error);
+          controller.error(error);
+        } finally {
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(transformStream, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      },
+    });
+
+  } catch (error) {
+    console.error("API route error:", error);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
 }


### PR DESCRIPTION
Proxy frontend chat requests to FastAPI backend to leverage existing backend logic.

The `chat-agent-app-ui` previously called OpenAI directly. This PR reconfigures the Next.js API route (`/api/chat`) to act as a proxy, forwarding requests to the user's FastAPI backend's `/api/v1/chat/stream` endpoint. It also handles the transformation between the Vercel AI SDK format (expected by the frontend) and the `AssistantUIRequest` format (expected by the backend), ensuring streaming responses work seamlessly. A `.env.local` file is added for configurable backend URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-31b14a91-d2bc-4458-bc61-d101dd87b9b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31b14a91-d2bc-4458-bc61-d101dd87b9b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

