### PR TITLE
Debug openwebui ollama routing error

### DIFF
--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -203,6 +203,10 @@ async def get_models():
 class OpenAIChatMessage(BaseModel):
     role: str
     content: str
+    
+    class Config:
+        # Allow extra fields that OpenWebUI might send
+        extra = "allow"
 
 
 class OpenAIChatRequest(BaseModel):
@@ -211,6 +215,10 @@ class OpenAIChatRequest(BaseModel):
     stream: bool = False
     temperature: float = 0.7
     max_tokens: int = 1000
+    
+    class Config:
+        # Allow extra fields that OpenWebUI might send
+        extra = "allow"
 
 
 @router.post("/chat/completions")
@@ -222,6 +230,9 @@ async def openai_chat_completions(
     """
     OpenAI-compatible chat completions endpoint for Open WebUI integration
     """
+    logger.info(f"Received chat completions request for model: {request.model}")
+    logger.info(f"Request messages count: {len(request.messages)}")
+    
     try:
         # Convert OpenAI format to our internal format
         if not request.messages:
@@ -305,6 +316,9 @@ async def openai_chat_completions(
             error_message = format_workflow_error(result, workflow_name)
             raise HTTPException(status_code=500, detail=error_message)
             
+    except HTTPException as e:
+        logger.error(f"HTTP error in chat completions: {e.status_code} - {e.detail}")
+        raise e
     except Exception as e:
-        logger.error(f"OpenAI chat completions error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Unexpected error in chat completions: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,12 +52,42 @@ async def root():
 async def health_check():
     return {"status": "healthy"}
 
+# Add OpenAI-compatible endpoints at root level for OpenWebUI discovery
+@app.get("/models")
+async def root_models():
+    """Root level models endpoint for OpenWebUI compatibility"""
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "medical-assistant",
+                "object": "model",
+                "created": 1677610602,
+                "owned_by": "medical-assistant",
+                "permission": [],
+                "root": "medical-assistant",
+                "parent": None
+            },
+            {
+                "id": "pubmed-research",
+                "object": "model", 
+                "created": 1677610602,
+                "owned_by": "medical-assistant",
+                "permission": [],
+                "root": "pubmed-research",
+                "parent": None
+            }
+        ]
+    }
+
 # Include API router
 app.include_router(api_router, prefix="/api/v1")
 
-# Include OpenAI-compatible endpoints at root level for OpenWebUI compatibility
+# Include OpenAI-compatible endpoints for OpenWebUI at multiple paths
 from app.api.v1.chat import router as chat_router
-app.include_router(chat_router, prefix="", tags=["openai-compat"])
+app.include_router(chat_router, prefix="/v1", tags=["openai-v1"])  # Standard OpenAI path
+app.include_router(chat_router, prefix="/api", tags=["openai-api"])  # What OpenWebUI is calling
+app.include_router(chat_router, prefix="", tags=["openai-root"])  # Root level as backup
 
 # Include WebSocket directly (not under API prefix)
 from app.api.v1.websocket import router as websocket_router

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,10 @@ async def health_check():
 # Include API router
 app.include_router(api_router, prefix="/api/v1")
 
+# Include OpenAI-compatible endpoints at root level for OpenWebUI compatibility
+from app.api.v1.chat import router as chat_router
+app.include_router(chat_router, prefix="", tags=["openai-compat"])
+
 # Include WebSocket directly (not under API prefix)
 from app.api.v1.websocket import router as websocket_router
 app.include_router(websocket_router, prefix="/ws")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       
       # Configure OpenAI-compatible endpoint to your FastAPI backend
       - OPENAI_BASE_URL=http://backend:8000
-      - OPENAI_API_KEY=dummy-key  # Required by OpenWebUI, can be dummy since your backend doesn't require auth
+      - OPENAI_API_KEY=sk-dummy-key-for-openwebui  # Required by OpenWebUI, can be dummy since your backend doesn't require auth
       
       # WebUI Configuration
       - WEBUI_SECRET_KEY=your-medical-assistant-secret-key-change-this

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,17 +69,27 @@ services:
     container_name: chatapp_open_webui
     restart: unless-stopped
     environment:
-      - OLLAMA_BASE_URL=  
+      # Disable Ollama completely
+      - OLLAMA_BASE_URL=
       - ENABLE_OLLAMA=false
+      
+      # Configure OpenAI-compatible endpoint to your FastAPI backend
+      - OPENAI_BASE_URL=http://backend:8000
+      - OPENAI_API_KEY=dummy-key  # Required by OpenWebUI, can be dummy since your backend doesn't require auth
+      
+      # WebUI Configuration
       - WEBUI_SECRET_KEY=your-medical-assistant-secret-key-change-this
       - WEBUI_AUTH=false 
-      - DEFAULT_MODELS=medical-assistant  # custom model name
+      - DEFAULT_MODELS=medical-assistant,pubmed-research  # Match your backend models
       - ENABLE_SIGNUP=true
       - ENABLE_LOGIN_FORM=true
       - WEBUI_NAME=Medical Assistant Chat
       - ENABLE_COMMUNITY_SHARING=false
       - ENABLE_MESSAGE_RATING=true
       - ENABLE_MODEL_FILTER=true
+      
+      # Additional configuration to ensure proper routing
+      - ENABLE_OPENAI_API=true
       - BACKEND_URL=http://backend:8000
     ports:
       - "3001:8080"  


### PR DESCRIPTION
Configure OpenWebUI to route chat requests to a FastAPI backend instead of Ollama.

OpenWebUI v0.6.5 requires explicit `OPENAI_BASE_URL` configuration and root-level OpenAI-compatible endpoints (`/models`, `/chat/completions`) to correctly route requests to a custom FastAPI backend, even when Ollama is disabled. This fixes 500 Server Connection Errors caused by incorrect routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0400b51-0e03-44d2-ad99-853992437c33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0400b51-0e03-44d2-ad99-853992437c33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

